### PR TITLE
Add streaming image generator web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ See `requirements.txt` for the list of Python packages used.
 
 ## Extending
 The code is written to allow additional platforms (e.g., Vimeo, Facebook) by adding new classes in `downloader.py`.
+
+## Image Generator Web App
+
+This repository also includes a small FastAPI application for generating images with OpenAI's `gpt-image-1` model. The app exposes a minimal web interface in Arabic that streams the image URL as it becomes available.
+
+### Running the server
+
+1. Create a `.env` file in the project root with your `OPENAI_API_KEY`.
+2. Install the requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Start the server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+4. Open `http://localhost:8000` in your browser and enter a prompt in Arabic or English.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,55 @@
+import os
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from dotenv import load_dotenv
+import openai
+import asyncio
+
+load_dotenv()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+templates = Jinja2Templates(directory="templates")
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+async def generate_image(prompt: str):
+    if not openai.api_key:
+        raise HTTPException(status_code=500, detail="API key not configured")
+
+    response = await openai.AsyncClient().images.generate(
+        model="gpt-image-1",
+        prompt=prompt,
+        n=1,
+        size="1024x1024",
+        stream=True,
+    )
+    async for chunk in response:
+        if "data" in chunk:
+            for part in chunk["data"]:
+                if url := part.get("url"):
+                    yield url
+
+
+@app.post("/generate")
+async def generate(request: Request):
+    data = await request.json()
+    prompt = data.get("prompt")
+    if not prompt:
+        raise HTTPException(status_code=400, detail="Prompt is required")
+
+    async def event_generator():
+        async for url in generate_image(prompt):
+            yield url + "\n"
+
+    return StreamingResponse(event_generator(), media_type="text/plain")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ yt-dlp
 pytube
 requests
 customtkinter
+fastapi
+uvicorn
+openai
+python-dotenv

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,37 @@
+document.getElementById('generate').addEventListener('click', async () => {
+    const prompt = document.getElementById('prompt').value.trim();
+    if (!prompt) return;
+
+    const result = document.getElementById('result');
+    result.textContent = '...';
+
+    const response = await fetch('/generate', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ prompt })
+    });
+
+    if (!response.ok) {
+        result.textContent = 'حدث خطأ';
+        return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let imageUrl = '';
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        imageUrl += decoder.decode(value, { stream: true });
+    }
+
+    imageUrl = imageUrl.trim();
+    if (imageUrl) {
+        result.innerHTML = `<img src="${imageUrl}" alt="result"> <a href="${imageUrl}" download>تحميل</a>`;
+    } else {
+        result.textContent = 'لم يتم الحصول على رابط الصورة';
+    }
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,21 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f0f0f0;
+}
+.container {
+    max-width: 600px;
+    margin: 50px auto;
+    text-align: center;
+}
+textarea {
+    width: 100%;
+    height: 100px;
+    margin-bottom: 10px;
+}
+img {
+    max-width: 100%;
+    height: auto;
+    margin-top: 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>مولد الصور</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <div class="container">
+        <h1>مولد الصور</h1>
+        <textarea id="prompt" placeholder="اكتب وصف الصورة هنا..."></textarea>
+        <button id="generate">توليد صورة</button>
+        <div id="result"></div>
+    </div>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI image generator using OpenAI `gpt-image-1`
- add simple HTML/JS frontend to send prompt and display streamed results
- store API keys in `.env`
- document the new web app in README
- include new dependencies and gitignore

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_b_687b2668b4a4832a87ceb6054f3e14a5